### PR TITLE
a11y: fix dark-theme contrast and gate both light + dark

### DIFF
--- a/dashboard/app/assets/css/main.css
+++ b/dashboard/app/assets/css/main.css
@@ -152,7 +152,9 @@
 
   --text:       var(--ink-9);
   --text-soft:  var(--ink-8);
-  --faint:      var(--ink-6);
+  /* ink-6 (#4a4a55) is far below AA on the raised dark surfaces (2.1:1).
+     Lightened to clear 4.5:1 on the worst dark surface while staying faint. */
+  --faint:      #858592;
 
   --accent-soft: var(--reef-soft-dark);
   --accent-fg:   #0a0a10;
@@ -176,7 +178,9 @@
   --secondary-foreground: #ffffff;
 
   --muted:                var(--ink-4);
-  --muted-foreground:     var(--ink-7);
+  /* ink-7 (#7c7c8a) renders at 4.45:1 on the raised #14141d surface — just
+     under AA. Lightened to clear 4.5:1 with margin on every dark surface. */
+  --muted-foreground:     #9a9aa8;
 
   /* shadcn convention: --accent is a NEUTRAL hover background, not the
      brand colour. Brand lives on --primary (and on --brand below for
@@ -225,7 +229,7 @@
   --chart-5: var(--danger-dark);
 
   --sidebar:                    var(--ink-1);
-  --sidebar-foreground:         var(--ink-7);
+  --sidebar-foreground:         #9a9aa8;
   --sidebar-primary:            var(--reef-dark);
   --sidebar-primary-foreground: #0a0a10;
   --sidebar-accent:             var(--ink-3);

--- a/dashboard/scripts/axe-authed.mjs
+++ b/dashboard/scripts/axe-authed.mjs
@@ -50,58 +50,71 @@ const ROUTES = [
 
 const SEVERITIES = new Set(["serious", "critical"])
 
+// Both color schemes are gated. The dashboard uses @nuxtjs/color-mode with
+// preference "system", so prefers-color-scheme picks the theme — and dark is
+// the fallback most users see. A light-only scan misses every dark-theme
+// contrast defect (and vice versa), so we scan each route in both.
+const SCHEMES = ["light", "dark"]
+
 async function main() {
   const browser = await chromium.launch()
-  const context = await browser.newContext()
-
-  // Seed the dev-mock auth token before any document script runs, on every
-  // navigation in this context — so each page.goto() boots authenticated.
-  await context.addInitScript(
-    ([key, token]) => {
-      try {
-        localStorage.setItem(key, token)
-      } catch {
-        /* about:blank etc. — ignored; set succeeds on the real origin */
-      }
-    },
-    [AUTH_TOKEN_KEY, DEV_MOCK_TOKEN],
-  )
-
-  const page = await context.newPage()
   const offenders = []
   let scanned = 0
 
-  for (const route of ROUTES) {
-    const url = BASE_URL + route
-    try {
-      await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 })
-      // Guard against silent redirect-to-login (auth didn't rehydrate).
-      if (new URL(page.url()).pathname.startsWith("/login") && route !== "/login") {
-        console.log(`::warning::${route} redirected to /login — auth did not rehydrate, skipped`)
-        continue
-      }
-      const results = await new AxeBuilder({ page })
-        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
-        .analyze()
-      scanned++
-      const serious = results.violations.filter((v) => SEVERITIES.has(v.impact))
-      if (serious.length) {
-        offenders.push([route, serious])
-        console.log(`✗ ${route} — ${serious.length} serious/critical`)
-        for (const v of serious) {
-          console.log(`    [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`)
+  for (const scheme of SCHEMES) {
+    const context = await browser.newContext({ colorScheme: scheme })
+
+    // Seed the dev-mock auth token before any document script runs, on every
+    // navigation in this context — so each page.goto() boots authenticated.
+    await context.addInitScript(
+      ([key, token]) => {
+        try {
+          localStorage.setItem(key, token)
+        } catch {
+          /* about:blank etc. — ignored; set succeeds on the real origin */
         }
-      } else {
-        console.log(`✓ ${route}`)
+      },
+      [AUTH_TOKEN_KEY, DEV_MOCK_TOKEN],
+    )
+
+    const page = await context.newPage()
+
+    for (const route of ROUTES) {
+      const url = BASE_URL + route
+      try {
+        await page.goto(url, { waitUntil: "networkidle", timeout: 30_000 })
+        // Guard against silent redirect-to-login (auth didn't rehydrate).
+        if (new URL(page.url()).pathname.startsWith("/login") && route !== "/login") {
+          console.log(`::warning::[${scheme}] ${route} redirected to /login — auth did not rehydrate, skipped`)
+          continue
+        }
+        const results = await new AxeBuilder({ page })
+          .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+          .analyze()
+        scanned++
+        const serious = results.violations.filter((v) => SEVERITIES.has(v.impact))
+        if (serious.length) {
+          offenders.push([scheme, route, serious])
+          console.log(`✗ [${scheme}] ${route} — ${serious.length} serious/critical`)
+          for (const v of serious) {
+            console.log(`    [${v.impact}] ${v.id}: ${v.help} (${v.nodes.length} node(s))`)
+          }
+        } else {
+          console.log(`✓ [${scheme}] ${route}`)
+        }
+      } catch (err) {
+        console.log(`::warning::[${scheme}] ${route} failed to scan: ${err.message}`)
       }
-    } catch (err) {
-      console.log(`::warning::${route} failed to scan: ${err.message}`)
     }
+
+    await context.close()
   }
 
   await browser.close()
 
-  console.log(`\nScanned ${scanned}/${ROUTES.length} routes; ${offenders.length} with serious/critical violations.`)
+  console.log(
+    `\nScanned ${scanned}/${ROUTES.length * SCHEMES.length} route×theme combos; ${offenders.length} with serious/critical violations.`,
+  )
   if (offenders.length) process.exit(1)
 }
 


### PR DESCRIPTION
## What

The authed-axe hard gate (PR #1) only scanned the app in **light mode** — headless Chromium defaults to `prefers-color-scheme: light`, but the dashboard's `@nuxtjs/color-mode` fallback is **dark**, which is what many users actually see. So the gate had a blind spot for an entire theme.

A dark-mode scan found **~99 serious contrast violations** the light-only gate never caught: muted/faint/sidebar text on the raised dark surfaces (`--faint`=ink-6 `#4a4a55` at 2.1:1, `--muted-foreground`/`--sidebar-foreground`=ink-7 `#7c7c8a` at 4.45:1).

## Fix

- Lightened the three dark-theme semantic tokens to clear AA 4.5:1 on every dark surface (`#858592` faint, `#9a9aa8` muted/sidebar). Dark **raw scales** (canon-pinned) untouched — only the dashboard's semantic mappings.
- Extended `scripts/axe-authed.mjs` to scan **every route in both light and dark** (`colorScheme` per context), so neither theme can regress.

## Verification

- Dark: 16/16 routes **0 serious/critical** (was ~99 violations).
- Light: still 16/16 **0** (no regression — only the dark block changed).
- Combined gate: **32/32 route×theme combos, 0 violations**.
- design-system 16/16 (contrast canon + drift), a11y-lint, i18n parity all green.

## Note on base

Stacked on `chore/green-main` (PR #2) because the dashboard CI build needs that PR's SDK-types fix to pass `sdk:check`. GitHub will retarget this to `main` once PR #2 merges.