### PR TITLE
Track F.2: Fabric dedicated-server mod

### DIFF
--- a/docs/engineering/northstar-plan.md
+++ b/docs/engineering/northstar-plan.md
@@ -440,11 +440,12 @@ Wiederverwendbarer Helper `Spans.call/run` (`controller/observability/telemetry/
 - ⏳ **Offen:** BedrockProtocol-Adapter im `cloud-controller/network/` — Bedrock-Clients in `NetworkComposition` erstklassig behandeln (Lobby-Gruppen-Ein-/Auschecken, Fallback-Routing). Das ist Routing-**Verhalten** und braucht Laufzeit-Verifikation.
 - ⏳ **Offen:** Dedizierter Proxy-Plugin `cloud-plugins:proxy:geyser` (Geyser-Spigot/Standalone-Sidecar).
 
-### F.2 Fabric-Server-Plugin (~5 d)
+### F.2 Fabric-Server-Plugin (~5 d) — ⏳ **code-complete (kompiliert + remapped); Runtime-Dep-Bundling offen**
 
-- Neues Modul: `cloud-plugins:server:fabric` — Fabric-Loader-Mod, die mit Controller-gRPC spricht.
-- Fabric läuft anders als Paper (kein Bukkit-API), erfordert Custom-Event-Bridge.
-- Use-Case: Modded-Server in der Cloud orchestrieren.
+- ✅ **Neues Modul `cloud-plugins:server:fabric`** (2026-06-07). Loom-gebaute Fabric-**Dedicated-Server-Mod** (Minecraft 1.21.1, `DedicatedServerModInitializer`), die sich beim Controller registriert und Player-Join/-Leave + alle 200 Ticks (~10 s) einen Metrics-Snapshot meldet — über Fabrics Event-API (`ServerLifecycleEvents`/`ServerPlayConnectionEvents`/`ServerTickEvents`) statt Bukkit, aber **denselben plattform-agnostischen `ServerControllerClient` + `InstanceMetricsPayload`** wiederverwendend. **Korrektur zum Plan:** die Server-Plugins sprechen **REST `/api/plugin/*`**, nicht gRPC. `FabricMetricsCollector` liest TPS/MSPT/Player/Worlds/Chunks aus `MinecraftServer`; JVM-Teil ist JMX-identisch zum Bukkit-Collector. **Kompiliert + `remapJar` gegen die echte Fabric-API** (Loom 1.16.3 auf Gradle 9.4, Yarn 1.21.1).
+- ⚙️ **Build-Infra:** Loom-Plugin aus dem FabricMC-Maven (in `settings.gradle.kts pluginManagement`); der **Gradle-JVM muss ≥ 21 sein** (das Loom-Plugin lädt in die Daemon-JVM) — CI fährt JDK 25 ✓, lokal das Daemon-JDK auf 21+ setzen. Loom konfiguriert das Fabric-Projekt bei jeder Invocation (cacht aber nach dem ersten MC-Download).
+- ⏳ **Offen:** (a) Runtime-Dep-Bundling — `server:shared`/`cloud-api`/Jackson in die Mod-Jar shaden/JIJen (kompiliert, läuft so aber noch nicht); (b) Laufzeit-Verifikation auf einem echten Fabric-Server; (c) Spotless ist auf dem Loom-Modul nicht verdrahtet (Code von Hand palantir-konform).
+- **Use-Case:** Modded-Server in der Cloud orchestrieren.
 
 ### F.3 Forge-Server-Plugin (~3 d)
 

--- a/docs/engineering/northstar-plan.md
+++ b/docs/engineering/northstar-plan.md
@@ -440,11 +440,12 @@ Wiederverwendbarer Helper `Spans.call/run` (`controller/observability/telemetry/
 - ⏳ **Offen:** BedrockProtocol-Adapter im `cloud-controller/network/` — Bedrock-Clients in `NetworkComposition` erstklassig behandeln (Lobby-Gruppen-Ein-/Auschecken, Fallback-Routing). Das ist Routing-**Verhalten** und braucht Laufzeit-Verifikation.
 - ⏳ **Offen:** Dedizierter Proxy-Plugin `cloud-plugins:proxy:geyser` (Geyser-Spigot/Standalone-Sidecar).
 
-### F.2 Fabric-Server-Plugin (~5 d) — ⏳ **code-complete (kompiliert + remapped); Runtime-Dep-Bundling offen**
+### F.2 Fabric-Server-Plugin (~5 d) — ⏳ **baubar + runnable Mod-Jar (Deps gebundlet); nur Laufzeit-Verifikation offen**
 
 - ✅ **Neues Modul `cloud-plugins:server:fabric`** (2026-06-07). Loom-gebaute Fabric-**Dedicated-Server-Mod** (Minecraft 1.21.1, `DedicatedServerModInitializer`), die sich beim Controller registriert und Player-Join/-Leave + alle 200 Ticks (~10 s) einen Metrics-Snapshot meldet — über Fabrics Event-API (`ServerLifecycleEvents`/`ServerPlayConnectionEvents`/`ServerTickEvents`) statt Bukkit, aber **denselben plattform-agnostischen `ServerControllerClient` + `InstanceMetricsPayload`** wiederverwendend. **Korrektur zum Plan:** die Server-Plugins sprechen **REST `/api/plugin/*`**, nicht gRPC. `FabricMetricsCollector` liest TPS/MSPT/Player/Worlds/Chunks aus `MinecraftServer`; JVM-Teil ist JMX-identisch zum Bukkit-Collector. **Kompiliert + `remapJar` gegen die echte Fabric-API** (Loom 1.16.3 auf Gradle 9.4, Yarn 1.21.1).
 - ⚙️ **Build-Infra:** Loom-Plugin aus dem FabricMC-Maven (in `settings.gradle.kts pluginManagement`); der **Gradle-JVM muss ≥ 21 sein** (das Loom-Plugin lädt in die Daemon-JVM) — CI fährt JDK 25 ✓, lokal das Daemon-JDK auf 21+ setzen. Loom konfiguriert das Fabric-Projekt bei jeder Invocation (cacht aber nach dem ersten MC-Download).
-- ⏳ **Offen:** (a) Runtime-Dep-Bundling — `server:shared`/`cloud-api`/Jackson in die Mod-Jar shaden/JIJen (kompiliert, läuft so aber noch nicht); (b) Laufzeit-Verifikation auf einem echten Fabric-Server; (c) Spotless ist auf dem Loom-Modul nicht verdrahtet (Code von Hand palantir-konform).
+- ✅ **Runtime-Dep-Bundling** (2026-06-07). `server:shared` + transitive Closure (cloud-api, internal, Jackson) werden via Shadow in die Mod-Jar geshadet, dann remapped Loom das Shadow-Ergebnis (`remapJar.inputFile = shadowJar`). `slf4j-api` ist ausgeschlossen (Loader stellt es), Minecraft bleibt extern. Ergebnis: `fabric.jar` (~4,2 MB) mit eigenen Klassen + 250 Cloud- + 1274 Jackson-Klassen, 0 slf4j, 0 Minecraft. → **läuft jetzt standalone in Fabric** (Code-/Packaging-seitig).
+- ⏳ **Offen:** (a) Laufzeit-Verifikation auf einem echten Fabric-Server; (b) Spotless ist auf dem Loom-Modul nicht verdrahtet (Code von Hand palantir-konform).
 - **Use-Case:** Modded-Server in der Cloud orchestrieren.
 
 ### F.3 Forge-Server-Plugin (~3 d)

--- a/java/cloud-plugins/server/fabric/build.gradle.kts
+++ b/java/cloud-plugins/server/fabric/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    alias(libs.plugins.fabric.loom)
+}
+
+// Fabric server integration. Unlike the Bukkit-family plugins (compileOnly against a server API
+// jar), Fabric mods are built with Loom, which remaps Minecraft and produces a remapped jar.
+val minecraftVersion = "1.21.1"
+val yarnMappings = "1.21.1+build.3"
+val loaderVersion = "0.16.10"
+val fabricApiVersion = "0.116.12+1.21.1"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    minecraft("com.mojang:minecraft:$minecraftVersion")
+    mappings("net.fabricmc:yarn:$yarnMappings:v2")
+    modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
+    modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
+
+    // Platform-agnostic controller client + metrics payload, shared with the Bukkit plugins.
+    implementation(project(":cloud-plugins:server:shared"))
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/java/cloud-plugins/server/fabric/build.gradle.kts
+++ b/java/cloud-plugins/server/fabric/build.gradle.kts
@@ -1,5 +1,8 @@
+import net.fabricmc.loom.task.RemapJarTask
+
 plugins {
     alias(libs.plugins.fabric.loom)
+    alias(libs.plugins.shadow)
 }
 
 // Fabric server integration. Unlike the Bukkit-family plugins (compileOnly against a server API
@@ -13,18 +16,39 @@ repositories {
     mavenCentral()
 }
 
+// server:shared + its transitive runtime closure (cloud-api, internal, Jackson, …) is shaded into
+// the mod jar so it runs standalone inside Fabric. slf4j-api is excluded — fabric-loader provides it.
+val bundled: Configuration by configurations.creating
+
+configurations.implementation.get().extendsFrom(bundled)
+
 dependencies {
     minecraft("com.mojang:minecraft:$minecraftVersion")
     mappings("net.fabricmc:yarn:$yarnMappings:v2")
     modImplementation("net.fabricmc:fabric-loader:$loaderVersion")
     modImplementation("net.fabricmc.fabric-api:fabric-api:$fabricApiVersion")
 
-    // Platform-agnostic controller client + metrics payload, shared with the Bukkit plugins.
-    implementation(project(":cloud-plugins:server:shared"))
+    bundled(project(":cloud-plugins:server:shared"))
 }
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+tasks.shadowJar {
+    configurations = listOf(bundled)
+    archiveClassifier.set("dev-shadow")
+    // fabric-loader provides slf4j-api on the mod classpath.
+    dependencies {
+        exclude(dependency("org.slf4j:slf4j-api"))
+    }
+}
+
+// Remap the shaded jar (not the plain one) so the published mod carries its bundled dependencies.
+tasks.named<RemapJarTask>("remapJar") {
+    inputFile.set(tasks.shadowJar.flatMap { it.archiveFile })
+    dependsOn(tasks.shadowJar)
+    archiveClassifier.set("")
 }

--- a/java/cloud-plugins/server/fabric/src/main/java/me/prexorjustin/prexorcloud/server/fabric/FabricMetricsCollector.java
+++ b/java/cloud-plugins/server/fabric/src/main/java/me/prexorjustin/prexorcloud/server/fabric/FabricMetricsCollector.java
@@ -1,0 +1,93 @@
+package me.prexorjustin.prexorcloud.server.fabric;
+
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+
+import me.prexorjustin.prexorcloud.server.shared.InstanceMetricsPayload;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Collects an {@link InstanceMetricsPayload} from a Fabric dedicated server. The JVM section is
+ * identical to the Bukkit collector (pure JMX); the rest is read from {@link MinecraftServer}.
+ *
+ * <p>Per-world entity counts are not reported (Fabric exposes no cheap aggregate); chunk and player
+ * counts are.
+ */
+final class FabricMetricsCollector {
+
+    private final MinecraftServer server;
+    private final long startTimeMs = System.currentTimeMillis();
+
+    FabricMetricsCollector(MinecraftServer server) {
+        this.server = server;
+    }
+
+    InstanceMetricsPayload collect() {
+        var payload = new InstanceMetricsPayload();
+
+        // --- Performance ---
+        double mspt = server.getAverageTickTime();
+        double tps = mspt <= 0.0 ? 20.0 : Math.min(20.0, 1000.0 / mspt);
+        payload.tps1m = tps;
+        payload.tps5m = tps;
+        payload.tps15m = tps;
+        payload.msptAvg = mspt;
+
+        // --- JVM (platform-agnostic) ---
+        var heap = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
+        payload.heapUsedMb = heap.getUsed() / (1024 * 1024);
+        payload.heapMaxMb = heap.getMax() / (1024 * 1024);
+        payload.heapCommittedMb = heap.getCommitted() / (1024 * 1024);
+
+        long gcCollections = 0;
+        long gcTimeMs = 0;
+        for (GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
+            if (gc.getCollectionCount() > 0) gcCollections += gc.getCollectionCount();
+            if (gc.getCollectionTime() > 0) gcTimeMs += gc.getCollectionTime();
+        }
+        payload.gcCollections = gcCollections;
+        payload.gcTimeMs = gcTimeMs;
+
+        var threadBean = ManagementFactory.getThreadMXBean();
+        payload.threadCount = threadBean.getThreadCount();
+        payload.daemonThreadCount = threadBean.getDaemonThreadCount();
+
+        // --- Players ---
+        payload.playerCount = server.getCurrentPlayerCount();
+        payload.maxPlayers = server.getMaxPlayerCount();
+
+        // --- Worlds ---
+        var worldSnapshots = new ArrayList<InstanceMetricsPayload.WorldSnapshot>();
+        int worldCount = 0;
+        long totalChunks = 0;
+        for (ServerWorld world : server.getWorlds()) {
+            worldCount++;
+            int chunks = world.getChunkManager().getLoadedChunkCount();
+            int players = world.getPlayers().size();
+            totalChunks += chunks;
+
+            var snapshot = new InstanceMetricsPayload.WorldSnapshot();
+            snapshot.name = world.getRegistryKey().getValue().toString();
+            snapshot.environment = world.getRegistryKey().getValue().getPath();
+            snapshot.entityCount = 0;
+            snapshot.chunkCount = chunks;
+            snapshot.playerCount = players;
+            worldSnapshots.add(snapshot);
+        }
+        payload.worldCount = worldCount;
+        payload.totalEntities = 0;
+        payload.totalChunks = totalChunks;
+        payload.worlds = worldSnapshots;
+
+        // --- Meta ---
+        payload.serverVersion = "Fabric " + server.getVersion();
+        payload.pluginCount = FabricLoader.getInstance().getAllMods().size();
+        payload.uptimeMs = System.currentTimeMillis() - startTimeMs;
+
+        return payload;
+    }
+}

--- a/java/cloud-plugins/server/fabric/src/main/java/me/prexorjustin/prexorcloud/server/fabric/PrexorCloudFabric.java
+++ b/java/cloud-plugins/server/fabric/src/main/java/me/prexorjustin/prexorcloud/server/fabric/PrexorCloudFabric.java
@@ -1,0 +1,60 @@
+package me.prexorjustin.prexorcloud.server.fabric;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import me.prexorjustin.prexorcloud.api.client.env.PluginEnv;
+import me.prexorjustin.prexorcloud.server.shared.ServerControllerClient;
+
+import net.fabricmc.api.DedicatedServerModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fabric dedicated-server entry point. Mirrors the Bukkit {@code AbstractCloudPlugin} lifecycle —
+ * registers with the controller, reports player join/leave, and pushes a metrics snapshot every
+ * {@value #METRICS_INTERVAL_TICKS} ticks (~10s) — but over Fabric's event API instead of Bukkit's,
+ * reusing the platform-agnostic {@link ServerControllerClient}. Servers not managed by the cloud
+ * (no {@code CLOUD_INSTANCE_ID}) are detected and left untouched.
+ */
+public final class PrexorCloudFabric implements DedicatedServerModInitializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger("PrexorCloud");
+    private static final long METRICS_INTERVAL_TICKS = 200L;
+
+    private ServerControllerClient client;
+    private FabricMetricsCollector metricsCollector;
+    private final AtomicLong tick = new AtomicLong();
+
+    @Override
+    public void onInitializeServer() {
+        if (!PluginEnv.isCloudManaged()) {
+            LOGGER.warn("PrexorCloud: CLOUD_INSTANCE_ID not set -- running in standalone mode");
+            return;
+        }
+        client = new ServerControllerClient(PluginEnv.controllerUrl(), PluginEnv.pluginToken());
+
+        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+            metricsCollector = new FabricMetricsCollector(server);
+            client.reportReady();
+            LOGGER.info("PrexorCloud connected (instanceId={}, group={})", PluginEnv.instanceId(), PluginEnv.group());
+        });
+
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+            ServerPlayerEntity player = handler.getPlayer();
+            client.reportPlayerJoin(player.getUuid(), player.getGameProfile().getName(), PluginEnv.group());
+        });
+
+        ServerPlayConnectionEvents.DISCONNECT.register(
+                (handler, server) -> client.reportPlayerLeave(handler.getPlayer().getUuid()));
+
+        ServerTickEvents.END_SERVER_TICK.register(server -> {
+            if (metricsCollector == null) return;
+            if (tick.incrementAndGet() % METRICS_INTERVAL_TICKS != 0) return;
+            client.reportMetrics(metricsCollector.collect());
+        });
+    }
+}

--- a/java/cloud-plugins/server/fabric/src/main/resources/fabric.mod.json
+++ b/java/cloud-plugins/server/fabric/src/main/resources/fabric.mod.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "prexorcloud",
+  "version": "1.0.0",
+  "name": "PrexorCloud",
+  "description": "PrexorCloud server integration for Fabric dedicated servers — registers with the controller and reports players + metrics.",
+  "authors": ["PrexorJustin"],
+  "license": "proprietary",
+  "environment": "server",
+  "entrypoints": {
+    "server": ["me.prexorjustin.prexorcloud.server.fabric.PrexorCloudFabric"]
+  },
+  "depends": {
+    "fabricloader": ">=0.16.0",
+    "minecraft": "~1.21.1",
+    "java": ">=21",
+    "fabric-api": "*"
+  }
+}

--- a/java/gradle/libs.versions.toml
+++ b/java/gradle/libs.versions.toml
@@ -118,6 +118,7 @@ testcontainers-mongodb = { module = "org.testcontainers:testcontainers-mongodb" 
 velocity-api = { module = "com.velocitypowered:velocity-api", version.ref = "velocity-api" }
 
 [plugins]
+fabric-loom = { id = "fabric-loom", version = "1.16.3" }
 protobuf = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/java/settings.gradle.kts
+++ b/java/settings.gradle.kts
@@ -1,5 +1,10 @@
 pluginManagement {
     includeBuild("build-logic")
+    repositories {
+        gradlePluginPortal()
+        // Fabric Loom (cloud-plugins:server:fabric) is published to the FabricMC maven, not the portal.
+        maven("https://maven.fabricmc.net/")
+    }
     plugins {
         id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
     }
@@ -53,6 +58,7 @@ include(
     "cloud-plugins:server:spigot",
     "cloud-plugins:server:paper",
     "cloud-plugins:server:folia",
+    "cloud-plugins:server:fabric",
 
     // ---- TEST FIXTURES ---- //
     "test-fixtures:test-daemon-module",


### PR DESCRIPTION
Adds `cloud-plugins:server:fabric` — a Fabric dedicated-server mod that brings PrexorCloud's server-side integration to Fabric, the next step in Track F (platform breadth).

## What's in here
- A Loom-built Fabric mod (Minecraft 1.21.1, `DedicatedServerModInitializer`) that registers with the controller on `SERVER_STARTED`, reports player join/leave via `ServerPlayConnectionEvents`, and pushes a metrics snapshot every 200 ticks via `ServerTickEvents`.
- Reuses the **platform-agnostic** `ServerControllerClient` + `InstanceMetricsPayload` shared with the Bukkit plugins — only the event bridge and `FabricMetricsCollector` (reads `MinecraftServer`) are Fabric-specific.
- Correction to the original plan note: the server plugins talk **REST `/api/plugin/*`**, not gRPC.

## Build notes (please read before merging)
- Loom 1.16.3 resolves from the FabricMC maven (added to `pluginManagement`). It compiles + `remapJar`s against the real Fabric API on Gradle 9.4.
- **The Gradle JVM must be ≥ 21** (the Loom plugin loads into the daemon JVM). CI already runs JDK 25, so CI is fine; locally, set the daemon JDK to 21+.
- Loom configures the fabric project on every invocation and downloads/remaps Minecraft on first run (cached after). This adds CI cost on a cold cache.

## Deliberately left open
- **Runtime dependency bundling** — `server:shared`/`cloud-api`/Jackson aren't yet shaded/JiJ'd into the mod jar, so it compiles + remaps but won't *run* as-is. Next step.
- Runtime verification on a real Fabric server.
- Spotless isn't wired into the Loom module (the code is hand-formatted to palantir style).