### PR TITLE
Drop logback from the Fabric mod jar

### DIFF
--- a/java/cloud-plugins/server/fabric/build.gradle.kts
+++ b/java/cloud-plugins/server/fabric/build.gradle.kts
@@ -40,9 +40,13 @@ java {
 tasks.shadowJar {
     configurations = listOf(bundled)
     archiveClassifier.set("dev-shadow")
-    // fabric-loader provides slf4j-api on the mod classpath.
+    // fabric-loader provides slf4j-api + a logging binding on the mod classpath. Bundling logback
+    // would drop a competing SLF4JServiceProvider into the mod jar and hijack the host's logging —
+    // exclude the binding and let the cloud code (slf4j-api only) log through the loader's.
     dependencies {
         exclude(dependency("org.slf4j:slf4j-api"))
+        exclude(dependency("ch.qos.logback:logback-classic"))
+        exclude(dependency("ch.qos.logback:logback-core"))
     }
 }
 


### PR DESCRIPTION
Follow-up to F.2, surfaced while building the NeoForge mod (#7).

The shaded Fabric mod jar bundled **730 logback classes + a `META-INF/services/org.slf4j.spi.SLF4JServiceProvider`**. Dropping a competing SLF4JServiceProvider inside a mod jar can hijack the host server's logging binding (slf4j picks a provider non-deterministically). fabric-loader already provides slf4j + a binding, so the cloud code — which only uses the slf4j *API* — should log through the loader's.

Same one-line build exclude the NeoForge module already carries.

## Verification

`fabric.jar`: **4.2 MB → 3.3 MB**, logback classes **730 → 0**, SLF4JServiceProvider service files **→ 0**. Cloud (292) + Jackson (1274) classes, `fabric.mod.json`, and zero-Minecraft-leak all intact. Builds with `./gradlew :cloud-plugins:server:fabric:remapJar` (Gradle JVM ≥ 21).