### PR TITLE
Track I — docs rewrite plan + I.0 style spec (v1.4)

### DIFF
--- a/docs/engineering/DOCS_STYLE.md
+++ b/docs/engineering/DOCS_STYLE.md
@@ -1,0 +1,173 @@
+# Docs & README style guide
+
+The single standard for everything written for humans in this repo: the public docs under `docs/public/`, every `README.md`, and the engineering notes under `docs/engineering/`. It exists so a reader can drop into any document and find the same voice, structure, and visual language — and so the upcoming docs rewrite (northstar Track I) is mechanical, not a debate.
+
+This guide follows its own rules. If a sentence here reads like an AI wrote it, that's a bug.
+
+---
+
+## 1. Who we write for
+
+Every document declares one primary audience in its first lines and is written for that reader's task — not for the engineer who built the feature.
+
+| Audience | Who they are | What they need | Where it lives |
+|---|---|---|---|
+| **Operator** | Runs PrexorCloud in production. On call at 2 AM. | Install, configure, upgrade, recover, observe. Copy-paste commands that work. | `docs/public/{getting-started,guides,operations,recipes}/`, deploy + installer READMEs |
+| **Integrator-developer** | Builds plugins, mods, or modules against our APIs. | A working minimal example, the capability surface, the contract. | `docs/public/{guides,reference}/`, `cloud-modules/*/README`, plugin READMEs |
+| **Contributor** | Hacks on PrexorCloud itself. | Architecture, build, test, where things live, why. | root `README`, `java/README`, `docs/engineering/`, module READMEs |
+
+When a document serves two audiences, split it with headings (`## For operators` / `## For developers`) rather than blending — never make an operator read internals to find a command.
+
+**The test:** could the intended reader finish their task from this page alone, without asking us? If not, it isn't done.
+
+---
+
+## 2. Voice
+
+House voice: **direct, concrete, calm.** Like the root README — "Built for the op on call at 2 AM, not the demo." We earn trust by being specific, not by adjectives.
+
+**Do**
+- Write in the active voice. *"The controller schedules the instance"* — not *"the instance is scheduled by the controller."*
+- Use second person for anything task-oriented. *"Run `prexorctl up`."*
+- Lead with the point. First sentence of every section answers "why am I reading this?"
+- Be specific and verifiable: name the file, the flag, the port, the exact error. "Fails with `422 SIGNATURE_VERIFICATION_FAILED`" beats "may not work."
+- Show, don't claim. A runnable example outranks a paragraph describing it.
+- Keep sentences short. One idea each. Prefer a list to a comma-spliced paragraph.
+
+**Don't**
+- No marketing adjectives as load-bearing words: *powerful, robust, seamless, blazing-fast, cutting-edge, enterprise-grade, effortless.* If it's robust, show the DR drill — don't say "robust."
+- No AI-essay hedging and filler. Banned openers and crutches: *"It's worth noting that", "In order to" (→ "to"), "simply" / "just", "leverage" (→ "use"), "utilize" (→ "use"), "in the world of", "at the end of the day", "a wide range of", "delve into", "this section will discuss", "as we can see".*
+- No "we" navel-gazing in user docs. The reader doesn't care how we felt about the design — they care what to type. (Engineering notes under `docs/engineering/` are the exception: there, "why we chose X over Y" is the point.)
+- No future/conditional tense for shipped behavior. "The daemon retries three times" — not "the daemon will retry."
+
+**Tone by surface:** public docs are instructional and warm; READMEs are crisp and confident; engineering notes are honest and opinionated (including about trade-offs and what's still open).
+
+---
+
+## 3. Headings, terms, and mechanics
+
+- **Sentence case headings.** "Getting started", not "Getting Started". (Enforced in the dashboard by `pnpm lint:voice`; apply it to prose too.)
+- **No emoji in product copy.** The prescribed CLI glyphs are fine and encouraged in terminal output and status lines: `✓ ✗ ● ○ → ▶ │ └ ├ … ⌘ ↵`. README hero/marketing badges are not emoji.
+- **One spelling per term.** Use the glossary below verbatim — casing matters.
+- **Code in fences with a language tag** (` ```bash `, ` ```java `, ` ```yaml `). Inline code for any filename, flag, env var, type, or command: `prexorctl`, `--node-id`, `CLOUD_INSTANCE_ID`, `StateStore`.
+- **Commands are copy-pasteable.** No leading `$`. Show expected output below the command when it matters.
+- **Link, don't repeat.** Each fact lives in one canonical place; everything else links to it. A broken or duplicated explanation is a bug.
+
+### Glossary (canonical terms)
+
+| Term | Use | Not |
+|---|---|---|
+| Controller | the control-plane process | "master", "server" |
+| Daemon | the per-node agent | "agent", "worker", "slave" |
+| Group | a scalable set of instances | "pool", "cluster" |
+| Instance | one running MC server/proxy process | "server" (ambiguous) |
+| Template | versioned config + files layer | "preset" |
+| Network | routing composition over groups | "proxy group" |
+| Module | controller-side extension (Capability API) | "addon" |
+| Plugin | the in-MC integration (Paper/Velocity/Fabric/NeoForge/Geyser) | "mod" (except actual Forge/Fabric mods) |
+| PrexorCloud | the product (one word, capital C) | "Prexor Cloud", "prexorcloud" in prose |
+| prexorctl | the CLI (lowercase, code font) | "PrexorCTL" |
+
+---
+
+## 4. Structure
+
+### Public docs are task-first, not subsystem-first
+
+Organize by what the reader is trying to do, not by how the code is split. The directory layout under `docs/public/<lang>/` reflects this:
+
+- `getting-started/` — zero to a running cluster, fast. The single most important page.
+- `guides/` — one task per page, start to finish ("Deploy a network", "Write your first module").
+- `operations/` — run it in production (upgrade, backup, DR, scaling, observability).
+- `recipes/` — short, copy-paste solutions to common setups.
+- `reference/` — exhaustive and dry (REST/CLI/config/capability surface). Generated where possible.
+- `concepts/` — the mental model (how scheduling works, the trust root). Read once, refer back.
+- `internals/` — for contributors; protocol, architecture.
+
+Every doc opens with a one-sentence "what you'll do here" and, for guides, a "before you start" prerequisites line.
+
+### READMEs follow the template
+
+Every `README.md` in the repo uses [`templates/README.template.md`](./templates/README.template.md). It is not optional and it is not per-author taste. See §5 for the required sections and the per-package matrix.
+
+---
+
+## 5. README standard
+
+A README answers four questions in under ten seconds of scrolling: **what is this, why would I use it, how do I start, where do I go next.** Everything else is secondary.
+
+**Required sections, in order:**
+1. **Hero** — centered: name, one-line tagline, the badge row. (Root + each top-level surface.)
+2. **One-paragraph "what"** — what this package is and the one job it does.
+3. **Quickstart** — the shortest path to it working. Copy-paste, no prose between steps.
+4. **Architecture / how it fits** — a short ASCII diagram or a sentence placing it in the system. Link to the deep-dive; don't inline it.
+5. **Usage / API** — the common operations, each with a runnable example.
+6. **Links** — docs, related packages, contributing.
+7. **License** — one line.
+
+Module/sub-package READMEs may drop the hero badges but keep the order.
+
+### Visual language
+
+- **Badges:** [shields.io](https://shields.io) `?style=flat-square`. Use the Reef palette for accent badges — `color=0c8aa8` (Reef light) for "docs"/info, standard semantic colors for build/license. Keep the row to ≤ 5; CI · License · Docs · Version is the canonical set.
+- **Diagrams:** ASCII for the README itself (renders everywhere, diffs cleanly), using the box glyphs `┌ ┐ └ ┘ │ ─ ├ ┤ ┬ ┴ v`. For docs pages, Mermaid in the design-system palette (primary Reef `#4ec5d4` dark / `#0c8aa8` light over ink/sand — see [`design-system.md`](./design-system.md)).
+- **Screenshots / GIFs:** for the dashboard, installer, and website only, where a picture genuinely beats words. Dark theme, the Reef accent, real data (no `lorem`). Store under the package's `docs/` or `assets/`.
+- **Color in prose:** none. Status uses the CLI glyphs, not colored text.
+
+### The hero (copy this exactly, swap the content)
+
+```markdown
+<p align="center">
+  <strong>PrexorCloud</strong><br>
+  <em>Minecraft cloud orchestration, production-grade by default.</em>
+</p>
+
+<p align="center">
+  <a href="…/actions"><img src="https://img.shields.io/github/actions/workflow/status/prexorjustin/prexorcloud/ci.yml?branch=main&style=flat-square" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
+  <a href="https://prexor.cloud"><img src="https://img.shields.io/badge/docs-prexor.cloud-0c8aa8?style=flat-square" alt="Docs"></a>
+</p>
+```
+
+### Per-package matrix
+
+The 16 READMEs and the audience each is written for. The sweep (Track I.3) brings every one to this standard.
+
+| README | Audience | Hero badges |
+|---|---|---|
+| `/README.md` | Contributor + operator | yes |
+| `installer/README.md` | Operator | yes |
+| `dashboard/README.md` | Contributor | yes |
+| `website/README.md` | Contributor | yes |
+| `design-system/README.md` | Contributor | yes |
+| `java/README.md` | Contributor | yes |
+| `docs/README.md` | Contributor | no |
+| `tools/`, `scripts/`, `deploy/*/` | Operator/contributor | no |
+| `java/cloud-modules/example/README.md` | Integrator-developer | no |
+| `dashboard/packages/vscode-extension/README.md` | Integrator-developer | yes (marketplace) |
+
+---
+
+## 6. Code examples
+
+Examples are the docs. Hold them to a higher bar than prose.
+
+- **Runnable and minimal.** The smallest thing that works, nothing decorative. It should compile/run as written.
+- **Copy-pasteable.** No `$` prompts, no `<placeholders>` without saying what to put there, no truncated `...` in the middle of something you're meant to run.
+- **Show the result.** For a command, show the output or the effect. For an API call, show the response shape.
+- **Real names, real values.** `survival-lobby`, `node-fra-1`, port `30000` — not `foo`, `mygroup`, `xxx`.
+- **One concept per example.** If it teaches two things, it's two examples.
+
+---
+
+## 7. Enforcement
+
+- `pnpm lint:voice` already guards sentence-case headings and no-emoji in the dashboard; the same rules apply to all prose here by convention.
+- A future `readme:lint` (Track I.3) may assert the required README sections and badge style. Until then, the per-package matrix in §5 is the checklist.
+- Dead links are a build failure once Track I.4 lands a link check. Until then: every link you add, you click.
+
+---
+
+## 8. The one-line summary
+
+Write for the reader's task, in plain direct prose, with runnable examples and a consistent visual frame — and link to the one canonical place for every fact. If you remember nothing else: **show the command, cut the adjectives, pick the reader.**

--- a/docs/engineering/northstar-plan.md
+++ b/docs/engineering/northstar-plan.md
@@ -553,8 +553,8 @@ Das Register deckt die unten skizzierten Entscheidungen ab (mit abweichender Num
 
 **Sequencing-Entscheidung:** **Zuletzt** ausführen — erst wenn E/F/H feature-complete sind, sonst churnt die Doku mit jedem User-facing-Change. **Ausnahme: I.0 (Style-/Voice-Spec) wird FRÜH definiert**, damit der spätere Rewrite mechanisch statt zur Diskussion wird.
 
-### I.0 Docs/README-Style- & Voice-Spec (~1 d) — **früh definieren**
-- Eine `docs/engineering/DOCS_STYLE.md`: Zielgruppen-Matrix (Operator vs. Developer), Voice/Tone-Regeln (aktiv, knapp, kein AI-Hedging — wiederverwendet die Dashboard-`lint-voice`-Prinzipien), Begriffs-Glossar, und ein **kanonisches README-Template** (Hero/Badges/Quickstart/Architektur/Contributing/Lizenz) im Design-System-Look. Optional ein `readme:lint`-Gate analog `i18n:check`.
+### I.0 Docs/README-Style- & Voice-Spec (~1 d) — ✅ **shipped (2026-06-07, vorgezogen)**
+- `docs/engineering/DOCS_STYLE.md` geliefert: Zielgruppen-Matrix (Operator / Integrator-Developer / Contributor), Voice-Regeln (aktiv, konkret, ruhig; Banned-Phrases-Liste gegen AI-Hedging; reuse der `lint:voice`-Prinzipien), Sentence-Case + CLI-Glyph-Konvention, Begriffs-Glossar (eine Schreibweise pro Term), Struktur-Standard (task-first), README-Standard (Pflicht-Sektionen + Badge-/Diagramm-/Screenshot-Visual-Language im Reef-Palette-Look) inkl. Per-Package-Matrix für alle 16 READMEs, Code-Beispiel-Bar und Enforcement-Pfad. Plus das kanonische `docs/engineering/templates/README.template.md`, das der I.3-Sweep kopiert. Self-compliant (sentence-case, keine Prosa-Emoji, alle Links aufgelöst).
 
 ### I.1 End-User-Docs (~4 d)
 - `docs/public/` (de+en) neu: Getting-Started, Install (Docker/native/Cluster), Betrieb, Upgrade, Troubleshooting, Recipes — aufgabenorientiert, nicht subsystem-orientiert.

--- a/docs/engineering/northstar-plan.md
+++ b/docs/engineering/northstar-plan.md
@@ -95,10 +95,13 @@ v1.2 ──── Track C: Modul-Ökosystem-Reife                       │ 28 e
 v1.3 ──── Track F: MC-Plattform-Breite & Bedrock-Tiefenausbau   │ 15 eng-days
           Track H: Polish, Performance, A11y, i18n              │ 10 eng-days
 
+v1.4 ──── Track I: Docs- & README-Komplett-Rewrite (End-User+Dev)│ 13 eng-days
+          (strikt nach E/F/H; I.0 Style-Spec darf vorgezogen werden)
+
 ──────────────────────────────────────────────────────────────
-Gesamt:                                                          115 eng-days
-                                                                ≈ 5–6 Monate bei 1 FTE
-                                                                ≈ 2.5–3 Monate bei 2 FTE
+Gesamt:                                                          128 eng-days
+                                                                ≈ 6–7 Monate bei 1 FTE
+                                                                ≈ 3–3.5 Monate bei 2 FTE
 ```
 
 ---
@@ -538,6 +541,37 @@ Das Register deckt die unten skizzierten Entscheidungen ab (mit abweichender Num
 
 ---
 
+## 9b. Track I — Docs- & README-Komplett-Rewrite (End-User + Developer)
+
+**Ziel:** Die gesamte Doku (`docs/`) **und jede README** im Repo von Grund auf neu schreiben — für echte Zielgruppen statt für uns selbst, im Projekt-Design-Standard, visuell überzeugend, ausführlich, best-practice.
+
+**Warum (Auslöser, 2026-06-07):**
+1. **Es hat sich viel geändert.** v1.1–v1.3 haben Subsysteme dazugebracht (Raft-Control-Plane, OTel, Modul-Registry, Bedrock/Fabric/NeoForge, Geyser-Provisioning) — die bestehende Doku beschreibt teils einen veralteten Stand.
+2. **Zu „KI-lastig" geschrieben.** Der Ton ist essayistisch/hedging statt direkt. Neuer Ton: knapp, aktiv, konkret, ohne Füllwörter.
+3. **Für UNS geschrieben, nicht für Zielgruppen.** Die Docs lesen sich wie ein internes Engineering-Log. Sie müssen für **(a) End-User/Operatoren** (installieren, betreiben, troubleshooten) und **(b) Plugin-/Mod-/Module-Developer** (gegen die APIs bauen) geschrieben sein — klar getrennt.
+4. **READMEs uneinheitlich & unattraktiv.** Jede README soll **einem projektweiten Design-Standard** folgen (Struktur, Badges, Hero, Code-Beispiele, Visuals) und visuell überzeugen.
+
+**Sequencing-Entscheidung:** **Zuletzt** ausführen — erst wenn E/F/H feature-complete sind, sonst churnt die Doku mit jedem User-facing-Change. **Ausnahme: I.0 (Style-/Voice-Spec) wird FRÜH definiert**, damit der spätere Rewrite mechanisch statt zur Diskussion wird.
+
+### I.0 Docs/README-Style- & Voice-Spec (~1 d) — **früh definieren**
+- Eine `docs/engineering/DOCS_STYLE.md`: Zielgruppen-Matrix (Operator vs. Developer), Voice/Tone-Regeln (aktiv, knapp, kein AI-Hedging — wiederverwendet die Dashboard-`lint-voice`-Prinzipien), Begriffs-Glossar, und ein **kanonisches README-Template** (Hero/Badges/Quickstart/Architektur/Contributing/Lizenz) im Design-System-Look. Optional ein `readme:lint`-Gate analog `i18n:check`.
+
+### I.1 End-User-Docs (~4 d)
+- `docs/public/` (de+en) neu: Getting-Started, Install (Docker/native/Cluster), Betrieb, Upgrade, Troubleshooting, Recipes — aufgabenorientiert, nicht subsystem-orientiert.
+
+### I.2 Developer-Docs (~4 d)
+- Plugin-/Proxy-/Server-Plugin-Dev-Guide (Paper/Velocity/Bungee/Fabric/NeoForge/Geyser), Module-SDK + Capability-API, Platform-Module-REST, OpenAPI→CLI→SDK-Flow. Jede öffentliche API mit lauffähigem Minimalbeispiel.
+
+### I.3 README-Sweep (~3 d)
+- **Jede** README im Repo (Root + jedes Modul/Package/Frontend) nach I.0-Template neu — konsistent, visuell, mit Quickstart + Links in die Docs.
+
+### I.4 Visual- & Konsistenz-Polish (~1 d)
+- Diagramme (Mermaid im Design-System-Palette), Screenshots/GIFs der Frontends, Cross-Linking, Dead-Link-Check.
+
+**Track-I-Gesamt: ~13 eng-days. Strikt nach E/F/H. I.0 vorgezogen.** → eigener v1.4-„Docs & DX"-Meilenstein (siehe §11).
+
+---
+
 ## 10. Was wir NICHT machen (bewusst out of scope)
 
 - **Cross-Region-Cluster.** Raft setzt low-latency same-region voraus. Multi-Region wäre eine eigene Layer, kein v1.x-Thema.
@@ -592,6 +626,20 @@ Das Register deckt die unten skizzierten Entscheidungen ab (mit abweichender Num
 - Performance-Tuning, A11y >=95, i18n DE/EN vollständig
 
 **Aufwand: ~25 eng-days. Realistisch: 5–7 Wochen.**
+
+### v1.4 — „Docs & DX" (Track I)
+
+**Inhalt:**
+- Komplette Doku-Neuschrift für End-User **und** Developer (aufgaben- statt subsystem-orientiert, neuer Ton)
+- Jede README im Design-Standard, visuell überzeugend
+- Style-/Voice-Spec + README-Template als wiederverwendbarer Gate
+
+**Erfolgs-Kriterien:**
+- Ein neuer Operator kommt ohne Rückfragen von 0 auf laufendes Cluster
+- Ein Plugin-/Module-Developer baut ein lauffähiges Beispiel allein aus den Docs
+- 0 tote Links, jede README folgt dem Template, `lint-voice` grün über die Docs
+
+**Aufwand: ~13 eng-days. Strikt nach v1.3 (I.0-Spec darf vorgezogen werden).**
 
 ---
 

--- a/docs/engineering/templates/README.template.md
+++ b/docs/engineering/templates/README.template.md
@@ -1,0 +1,68 @@
+<!--
+  Canonical README template — see ../DOCS_STYLE.md.
+  Copy this file, fill every {{PLACEHOLDER}}, delete the sections that don't apply,
+  and delete this comment. Keep the section order. Sentence-case headings, no emoji
+  in prose (CLI glyphs ✓ → ● are fine), runnable copy-paste examples, link don't repeat.
+  Module/sub-package READMEs may drop the hero badges but keep the order.
+-->
+
+<p align="center">
+  <strong>{{NAME}}</strong><br>
+  <em>{{ONE_LINE_TAGLINE — what it is, in under ten words}}</em>
+</p>
+
+<!-- Badge row: keep ≤5. CI · License · Docs · Version is canonical. Reef accent = 0c8aa8. -->
+<p align="center">
+  <a href="https://github.com/prexorjustin/prexorcloud/actions"><img src="https://img.shields.io/github/actions/workflow/status/prexorjustin/prexorcloud/ci.yml?branch=main&style=flat-square" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square" alt="License"></a>
+  <a href="https://prexor.cloud"><img src="https://img.shields.io/badge/docs-prexor.cloud-0c8aa8?style=flat-square" alt="Docs"></a>
+</p>
+
+---
+
+## What is {{NAME}}?
+
+{{One paragraph. What this package is and the single job it does. Name the audience
+implicitly by the task — operator, integrator-developer, or contributor. No adjectives
+doing the work; state what it does and for whom.}}
+
+## Quickstart
+
+{{The shortest path from nothing to it working. Copy-paste, no prose between steps.
+Show the result.}}
+
+```bash
+{{command}}
+```
+
+```
+{{expected output}}
+```
+
+## How it fits
+
+{{A short ASCII diagram or one sentence placing this in the system. Link the deep-dive,
+don't inline it.}}
+
+```
+{{ascii diagram using ┌ ┐ └ ┘ │ ─ ├ ┤ v — or delete this block and use a sentence}}
+```
+
+## Usage
+
+{{The common operations, each a runnable minimal example with its result. One concept
+per example. Real names and values.}}
+
+## {{For developers | For operators}}
+
+{{Optional. When the package serves two audiences, split here instead of blending.}}
+
+## Links
+
+- [Documentation]({{https://prexor.cloud/...}})
+- [{{Related package}}]({{../path}})
+- [Contributing](../CONTRIBUTING.md)
+
+## License
+
+{{Apache 2.0}} — see [LICENSE](./LICENSE).


### PR DESCRIPTION
Sets up the v1.4 docs & README overhaul, and ships the one piece we agreed is safe to start early: the style standard itself.

## Plan (§9b Track I + v1.4 milestone)
Captures the docs/README rewrite as a tracked workstream — I.0 style spec, I.1 end-user docs, I.2 developer docs, I.3 README sweep (all 16), I.4 visual polish — sequenced **last**, after E/F/H. Website German translation folded in from H.3 (Track I rewrites all docs in en+de anyway). Roadmap updated to 128 eng-days.

## I.0 shipped (the early, safe foundation)
- **`docs/engineering/DOCS_STYLE.md`** — audience matrix (operator / integrator-developer / contributor), direct-voice rules with a banned-phrases list against AI-hedging, sentence-case + CLI-glyph conventions, a one-spelling glossary, task-first doc structure, the README standard + visual language (Reef-palette badges, ASCII/Mermaid diagrams), a per-package matrix for all 16 READMEs, the code-example bar, and the enforcement path.
- **`docs/engineering/templates/README.template.md`** — the canonical template the I.3 sweep copies.
- Self-compliant: sentence-case headings, no prose emoji, all internal links resolve.

**Why now:** much has shipped since the docs were written; they read AI-heavy and internal-facing rather than for end-users and plugin/mod/module developers; READMEs are inconsistent. Defining the standard early makes the eventual rewrite mechanical.